### PR TITLE
feat/qs-with-no-params-must-show-the-current-status

### DIFF
--- a/internal/cmdproc/cmdproc.go
+++ b/internal/cmdproc/cmdproc.go
@@ -265,6 +265,14 @@ func ExecRootCmd(ctx context.Context, args []string) (context.Context, error) {
 		upgradeCmd(ctx),
 		versionCmd(ctx),
 	)
+	rootCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		wd, err := getWorkingDir(params)
+		if err != nil {
+			return err
+		}
+
+		return gitcmds.Status(wd)
+	}
 	initChangeDirFlags(rootCmd.Commands(), params)
 
 	return ExecCommandAndCatchInterrupt(rootCmd)


### PR DESCRIPTION
Resolves #3894 feat/qs with no params must show the current status
