### PR TITLE
q/ suppress "You are in main branch" message in 'u'

### DIFF
--- a/internal/commands/u.go
+++ b/internal/commands/u.go
@@ -25,7 +25,7 @@ func U(cmd *cobra.Command, cfgUpload vcs.CfgUpload, wd string) error {
 		return err
 	}
 	if isMain {
-		fmt.Println("You are in main branch.")
+		logger.Verbose("You are in main branch.")
 	}
 
 	// Fetch notes from origin


### PR DESCRIPTION
Resolves #3993 q/ suppress "You are in main branch" message in 'u'