### PR TITLE
[AIR-3017] qs: eliminate redudant git operations + use single commit message instead of set of messages on `qs u -m`

### DIFF
--- a/gitcmds/pr.go
+++ b/gitcmds/pr.go
@@ -19,8 +19,7 @@ type PRInfo struct {
 }
 
 func Pr(wd string, needDraft bool) error {
-	// find out the type of the branch
-	branchType, err := GetBranchType(wd)
+	currentBranchName, branchType, err := GetBranchType(wd)
 	if err != nil {
 		return err
 	}
@@ -30,27 +29,25 @@ func Pr(wd string, needDraft bool) error {
 		return errors.New("you must be on dev or pr branch")
 	}
 
-	currentBranchName, err := GetCurrentBranchName(wd)
-	if err != nil {
-		return err
-	}
-
 	parentRepoName, err := GetParentRepoName(wd)
 	if err != nil {
 		return err
 	}
 
-	// Fetch notes from origin before checking if they exist
+	mainBranch, err := GetMainBranch(wd)
+	if err != nil {
+		return err
+	}
+
 	_, _, err = new(exec.PipedExec).
 		Command(git, fetch, origin, "--force", refsNotes).
 		WorkingDir(wd).
 		RunToStrings()
 	if err != nil {
 		logger.Verbose(fmt.Sprintf("Failed to fetch notes: %v", err))
-		// Continue anyway, as notes might exist locally
 	}
 
-	notes, revCount, err := GetNotes(wd, currentBranchName)
+	notes, revCount, err := getNotesWithMainBranch(wd, currentBranchName, mainBranch)
 	if err != nil {
 		return err
 	}
@@ -92,8 +89,7 @@ func Pr(wd string, needDraft bool) error {
 			return errors.New(errMsgModFiles)
 		}
 
-		// Create a new branch for the PR
-		prBranchName, err := createPRBranch(wd, currentBranchName, issueDescription)
+		prBranchName, err := createPRBranch(wd, currentBranchName, issueDescription, notes, revCount, upstreamExists, mainBranch)
 		if err != nil {
 			return fmt.Errorf("failed to create PR branch: %w", err)
 		}
@@ -123,8 +119,7 @@ func Pr(wd string, needDraft bool) error {
 		return nil
 	}
 
-	// Extract notes before any operations
-	notes, revCount, err = GetNotes(wd, currentBranchName)
+	notes, revCount, err = getNotesWithMainBranch(wd, currentBranchName, mainBranch)
 	if err != nil {
 		return err
 	}
@@ -327,14 +322,7 @@ func RemoveBranch(wd, branchName string) error {
 // Returns:
 // - name of the PR branch
 // - error if any operation fails
-func createPRBranch(wd, devBranchName, issueDescription string) (string, error) {
-	// Step 1: Get issue description from notes for a commit message
-	// extract notes from the dev branch before any operations
-	notes, revCount, err := GetNotes(wd, devBranchName)
-	if err != nil {
-		return "", err
-	}
-	// get json notes object from dev branch
+func createPRBranch(wd, devBranchName, issueDescription string, notes []string, revCount int, upstreamExists bool, mainBranchName string) (string, error) {
 	notesObj, ok := notesPkg.Deserialize(notes)
 	if !ok {
 		return "", errors.New("error deserializing notes")
@@ -352,16 +340,6 @@ func createPRBranch(wd, devBranchName, issueDescription string) (string, error) 
 	prBranchName := strings.TrimSuffix(devBranchName, "-dev") + "-pr"
 
 	upstreamRemote := "upstream"
-	upstreamExists, err := HasRemote(wd, upstreamRemote)
-	if err != nil {
-		return "", err
-	}
-
-	mainBranchName, err := GetMainBranch(wd)
-	if err != nil {
-		return "", fmt.Errorf("failed to get main branch: %w", err)
-	}
-
 	if !upstreamExists {
 		upstreamRemote = "origin"
 	}
@@ -370,6 +348,7 @@ func createPRBranch(wd, devBranchName, issueDescription string) (string, error) 
 	var (
 		stdout string
 		stderr string
+		err    error
 	)
 
 	// Step 3: Fetch the latest upstream main

--- a/gitcmds/pr.go
+++ b/gitcmds/pr.go
@@ -78,6 +78,7 @@ func Pr(wd string, needDraft bool) error {
 			if err := MakeUpstreamForBranch(wd, parentRepoName); err != nil {
 				return err
 			}
+			upstreamExists = true
 		}
 
 		// Check if there are any modified files in the current branch

--- a/internal/cmdproc/cmdproc.go
+++ b/internal/cmdproc/cmdproc.go
@@ -32,7 +32,7 @@ func updateCmd(_ context.Context, params *qsGlobalParams) *cobra.Command {
 			return commands.U(cmd, cfgUpload, wd)
 		},
 	}
-	uploadCmd.Flags().StringSliceVarP(&cfgUpload.Message, pushMessageWord, pushMessageParam, []string{}, pushMsgComment)
+	uploadCmd.Flags().StringVarP(&cfgUpload.Message, pushMessageWord, pushMessageParam, "", pushMsgComment)
 
 	return uploadCmd
 }

--- a/internal/cmdproc/consts.go
+++ b/internal/cmdproc/consts.go
@@ -5,8 +5,7 @@ const (
 	pushParamDesc    = "Upload sources to repo"
 	pushMessageWord  = "message"
 	pushMessageParam = "m"
-	pushMsgComment   = `Use the given string as the commit message. If multiple -m options are given
- their values are concatenated as separate paragraphs`
+	pushMsgComment   = "Use the given string as the commit message"
 
 	pullParamDesc = "Download sources from repo"
 

--- a/internal/commands/dev.go
+++ b/internal/commands/dev.go
@@ -66,11 +66,15 @@ func Dev(cmd *cobra.Command, wd string, args []string) error {
 		return fmt.Errorf("you are in %s/%s repo with upstream remote but no fork detected\nExecute 'qs fork' first", org, repo)
 	}
 
-	curBranch, isMain, err := gitcmds.IamInMainBranch(wd)
+	curBranch, err := gitcmds.GetCurrentBranchName(wd)
 	if err != nil {
 		return err
 	}
-	if !isMain {
+	mainBranch, err := gitcmds.GetMainBranch(wd)
+	if err != nil {
+		return err
+	}
+	if !strings.EqualFold(curBranch, mainBranch) {
 		fmt.Println("--------------------------------------------------------")
 		fmt.Println("You are in")
 		repo, org, err := gitcmds.GetRepoAndOrgName(wd)
@@ -97,7 +101,7 @@ func Dev(cmd *cobra.Command, wd string, args []string) error {
 	}
 
 	// sync local MainBranch to ensure it's up to date with origin and upstream remotes
-	if err := gitcmds.SyncMainBranch(wd); err != nil {
+	if err := gitcmds.SyncMainBranch(wd, mainBranch, upstreamExists); err != nil {
 		return err
 	}
 
@@ -171,7 +175,7 @@ func Dev(cmd *cobra.Command, wd string, args []string) error {
 			}
 		}
 
-		if err := gitcmds.CreateDevBranch(wd, branch, notes, checkRemoteBranchExistence); err != nil {
+		if err := gitcmds.CreateDevBranch(wd, branch, mainBranch, notes, checkRemoteBranchExistence); err != nil {
 			return err
 		}
 	default:

--- a/internal/systrun/types.go
+++ b/internal/systrun/types.go
@@ -550,12 +550,11 @@ func ExpectationRemoteBranchWithCommitMessage(ctx context.Context) error {
 		return fmt.Errorf("failed to get last commit message: %w: %s", err, stderr)
 	}
 
-	commitMessageParts, ok := ctx.Value(contextCfg.CtxKeyCommitMessage).([]string)
+	commitMessage, ok := ctx.Value(contextCfg.CtxKeyCommitMessage).(string)
 	if !ok {
 		return fmt.Errorf("commit message not found in context")
 	}
 
-	commitMessage := strings.Join(commitMessageParts, " ")
 	if !strings.Contains(stdout, commitMessage) {
 		return fmt.Errorf("remote branch %s does not have commit message '%s'", remoteBranchName, commitMessage)
 	}

--- a/uspecs/changes/archive/2602/2602211348-optimize-redundant-git-cmds/change.md
+++ b/uspecs/changes/archive/2602/2602211348-optimize-redundant-git-cmds/change.md
@@ -1,0 +1,20 @@
+---
+registered_at: 2026-02-21T10:29:07Z
+change_id: 2602211027-optimize-redundant-git-cmds
+baseline: f0a612b46c300f655a9cec0a3ef443583470b4fb
+archived_at: 2026-02-21T13:48:11Z
+---
+
+# Change request: Investigate and optimize redundant executions of git commands
+
+## Why
+
+The codebase may execute the same or similar git commands multiple times during a single operation (e.g., during upload or PR workflows), resulting in unnecessary process spawning and degraded performance.
+
+## What
+
+Investigate and optimize redundant git command executions:
+
+- Audit all git command invocations across the codebase to identify redundant or duplicate calls within the same workflow
+- Identify patterns where the same git information is fetched multiple times instead of being cached or passed through
+- Refactor to eliminate redundant executions by reusing results or restructuring call chains

--- a/uspecs/changes/archive/2602/2602211348-optimize-redundant-git-cmds/impl.md
+++ b/uspecs/changes/archive/2602/2602211348-optimize-redundant-git-cmds/impl.md
@@ -1,0 +1,59 @@
+# Implementation plan
+
+## Construction
+
+### Investigation findings
+
+The following redundant git command execution patterns were identified across command workflows:
+
+| Workflow             | Redundancy              | Times called | Needed |
+|----------------------|-------------------------|:------------:|:------:|
+| `qs u`               | `GetCurrentBranchName`  |      3       |   1    |
+| `qs u`               | `GetMainBranch`         |      2       |   1    |
+| `qs u`               | `git status` variants   |      2       |   1    |
+| `qs pr` (dev branch) | `GetMainBranch`         |      5       |   1    |
+| `qs pr` (dev branch) | `GetNotes`              |      4       |   1    |
+| `qs pr` (dev branch) | `GetCurrentBranchName`  |      2       |   1    |
+| `qs pr` (dev branch) | `HasRemote("upstream")` |      2       |   1    |
+| `qs pr` (dev branch) | fetch notes from origin |      3       |   1    |
+| `qs dev`             | `GetMainBranch`         |      3       |   1    |
+| `qs dev`             | `HasRemote("upstream")` |      3       |   1    |
+| `qs d`               | `GetMainBranch`         |      3       |   1    |
+| `qs d`               | `IamInMainBranch`       |      2       |   1    |
+| `qs d`               | `GetCurrentBranchName`  |      2       |   1    |
+
+### Core library changes
+
+- [x] update: [gitcmds/gitcmds.go](../../../../../gitcmds/gitcmds.go)
+  - refactor: `Download()` — eliminate second `IamInMainBranch` call and redundant `GetMainBranch` by reusing values from the first call
+  - refactor: `Upload()` — accept current branch name as parameter instead of re-calling `GetCurrentBranchName`
+  - refactor: `SyncMainBranch()` — accept pre-computed `mainBranch` and `upstreamExists` to avoid re-fetching inside
+  - refactor: `CreateDevBranch()` — accept pre-computed `mainBranch` to avoid redundant `GetMainBranch` call
+  - refactor: `GetNotes()` — split into public wrapper + internal `getNotesWithMainBranch()` to avoid `GetMainBranch` call
+  - refactor: `GetBranchType()` — return current branch name alongside type to let callers reuse it
+
+- [x] update: [gitcmds/pr.go](../../../../../gitcmds/pr.go)
+  - refactor: `Pr()` — reuse branch name from `GetBranchType`, get `mainBranch` once, use `getNotesWithMainBranch` for both notes calls
+  - refactor: `createPRBranch()` — accept pre-computed notes, revCount, upstream status, and main branch from `Pr()`
+
+### Command layer changes
+
+- [x] update: [internal/commands/u.go](../../../../../internal/commands/u.go)
+  - refactor: `U()` — capture `currentBranch` from `IamInMainBranch` and pass to `Upload`
+  - refactor: `setCommitMessage()` — updated `GetBranchType` call to match new 3-return signature
+
+- [x] update: [internal/commands/dev.go](../../../../../internal/commands/dev.go)
+  - refactor: `Dev()` — replaced `IamInMainBranch` with `GetCurrentBranchName` + `GetMainBranch`, pass pre-computed values to `SyncMainBranch` and `CreateDevBranch`
+
+### Tests
+
+- [x] update: [gitcmds/gitcmds_test.go](../../../../../gitcmds/gitcmds_test.go)
+  - no changes needed: tests use `GetNoteAndURL` helper, not changed signatures
+
+- [x] update: [sys_test.go](../../../../../sys_test.go)
+  - no changes needed: system tests use CLI framework, not direct function calls
+
+- [x] review: Verify no regressions
+  - `go build ./...` compiles without errors
+  - `go test ./gitcmds/... ./internal/... -count=1 -short` — all tests pass
+

--- a/uspecs/changes/archive/2602/2602211541-u-cmd-single-msg-string/change.md
+++ b/uspecs/changes/archive/2602/2602211541-u-cmd-single-msg-string/change.md
@@ -1,0 +1,20 @@
+---
+registered_at: 2026-02-21T15:24:38Z
+change_id: 2602211523-u-cmd-single-msg-string
+baseline: 9918beb30385990b9c46f289f3e6d3ad5b1e44f5
+archived_at: 2026-02-21T15:41:38Z
+---
+
+# Change request: Make commit message a single string in u command
+
+## Why
+
+The `u` command currently accepts commit message as a string slice (`[]string`) via `-m` flag, but a commit message is semantically a single string. Using a slice adds unnecessary complexity for both the caller and the implementation.
+
+## What
+
+Change the commit message parameter type from `[]string` to `string` across all layers:
+
+- `vcs.CfgUpload.Message` field type from `[]string` to `string`
+- Flag binding from `StringSliceVarP` to `StringVarP`
+- All usages that join or iterate over the message slice

--- a/uspecs/changes/archive/2602/2602211541-u-cmd-single-msg-string/impl.md
+++ b/uspecs/changes/archive/2602/2602211541-u-cmd-single-msg-string/impl.md
@@ -1,0 +1,22 @@
+# Implementation plan
+
+## Construction
+
+- [x] update: [vcs/cmdconfigs.go](../../../../../vcs/cmdconfigs.go)
+  - update: `CfgUpload.Message` field type from `[]string` to `string`
+
+- [x] update: [internal/cmdproc/cmdproc.go](../../../../../internal/cmdproc/cmdproc.go)
+  - update: flag binding from `StringSliceVarP` to `StringVarP`, default from `[]string{}` to `""`
+
+- [x] update: [internal/cmdproc/consts.go](../../../../../internal/cmdproc/consts.go)
+  - update: `pushMsgComment` to reflect single string semantics
+
+- [x] update: [internal/commands/u.go](../../../../../internal/commands/u.go)
+  - refactor: `setCommitMessage()` — replace slice operations with single string length check, store `string` in context instead of `[]string`
+
+- [x] update: [gitcmds/gitcmds.go](../../../../../gitcmds/gitcmds.go)
+  - refactor: `Upload()` — read commit message as `string` from context, pass single `-m` flag instead of iterating over slice
+
+- [x] update: [internal/systrun/types.go](../../../../../internal/systrun/types.go)
+  - update: `ExpectationRemoteBranchWithCommitMessage()` — read commit message as `string` from context instead of `[]string`
+

--- a/vcs/cmdconfigs.go
+++ b/vcs/cmdconfigs.go
@@ -2,7 +2,7 @@ package vcs
 
 // CfgUpload defines upload command config
 type CfgUpload struct {
-	Message []string
+	Message string
 }
 
 // CfgDownload defines download command config


### PR DESCRIPTION
[AIR-3017] qs: eliminate redudant git operations + use single commit message instead of set of messages on `qs u -m`
https://untill.atlassian.net/browse/AIR-3017

[AIR-3017]: https://untill.atlassian.net/browse/AIR-3017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ