### PR TITLE
[AIR-3060] Add strict error handling to uspecs utils script

### DIFF
--- a/uspecs/u/scripts/_lib/utils.sh
+++ b/uspecs/u/scripts/_lib/utils.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -Eeuo pipefail
 
 # checkcmds command1 [command2 ...]
 # Verifies that each listed command is available on PATH.

--- a/uspecs/u/uspecs.yml
+++ b/uspecs/u/uspecs.yml
@@ -3,6 +3,6 @@
 version: 0.1.0-a0
 invocation_methods: [nlia]
 installed_at: 2026-02-21T18:48:11Z
-modified_at: 2026-02-24T13:43:06Z
-commit: 3b41fb50b26de03cbc8e620f1de4ab2531f1ef28
-commit_timestamp: 2026-02-24T13:32:43Z
+modified_at: 2026-02-24T14:03:05Z
+commit: c4732720f507fa263f7f9623ab52175639607a35
+commit_timestamp: 2026-02-24T14:02:04Z


### PR DESCRIPTION
Add strict error handling to uspecs utils script

Adds set -Eeuo pipefail to _lib/utils.sh to enable strict error handling. Updates uspecs.yml metadata to reflect the latest commit.